### PR TITLE
Fix bug where ingredients were not falling when dropped. Also, add logic that checks if ingredient can be cooked with player's current active power.

### DIFF
--- a/Assets/Prefabs/BaconGO.prefab
+++ b/Assets/Prefabs/BaconGO.prefab
@@ -373,7 +373,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7100626090177149643}
-  m_BodyType: 0
+  m_BodyType: 2
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0

--- a/Assets/Prefabs/BaconGO.prefab
+++ b/Assets/Prefabs/BaconGO.prefab
@@ -412,3 +412,15 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.9258933, y: 2.313403}
   m_EdgeRadius: 0
+--- !u!114 &1806601770126516104
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7100626090177149643}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 788a1de919df9461c82781b8a42c21d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/ChickenGO.prefab
+++ b/Assets/Prefabs/ChickenGO.prefab
@@ -285,6 +285,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.9258933, y: 2.313403}
   m_EdgeRadius: 0
+--- !u!114 &1060529871410632531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2169196570510905347}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 788a1de919df9461c82781b8a42c21d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &7351499930605033619 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3567070737113872544, guid: 260c0618c31a54803a59d6b16f98bbbf, type: 3}

--- a/Assets/Prefabs/ChickenGO.prefab
+++ b/Assets/Prefabs/ChickenGO.prefab
@@ -246,7 +246,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2169196570510905347}
-  m_BodyType: 0
+  m_BodyType: 2
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0

--- a/Assets/Prefabs/LettuceGO.prefab
+++ b/Assets/Prefabs/LettuceGO.prefab
@@ -83,5 +83,23 @@ PrefabInstance:
       propertyPath: m_Name
       value: lettuce
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 267957810664289459, guid: 4e57ab3138f6644da91ad5d8fe98bcb6, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 4e57ab3138f6644da91ad5d8fe98bcb6, type: 3}
+--- !u!1 &1938594621337947244 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8916175496185270622, guid: 4e57ab3138f6644da91ad5d8fe98bcb6, type: 3}
+  m_PrefabInstance: {fileID: 7015442560176790834}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &558847668007123044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938594621337947244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 788a1de919df9461c82781b8a42c21d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/LettuceGO.prefab
+++ b/Assets/Prefabs/LettuceGO.prefab
@@ -12,6 +12,10 @@ PrefabInstance:
       value: 12.62
       objectReference: {fileID: 0}
     - target: {fileID: 1487534805995875697, guid: 4e57ab3138f6644da91ad5d8fe98bcb6, type: 3}
+      propertyPath: m_BodyType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1487534805995875697, guid: 4e57ab3138f6644da91ad5d8fe98bcb6, type: 3}
       propertyPath: m_Constraints
       value: 3
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/SoupGO.prefab
+++ b/Assets/Prefabs/SoupGO.prefab
@@ -333,6 +333,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: soup
       objectReference: {fileID: 0}
+    - target: {fileID: 8218941959952538807, guid: 91d22e101f4254fa5ba1ba25727b46de, type: 3}
+      propertyPath: m_BodyType
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 91d22e101f4254fa5ba1ba25727b46de, type: 3}
 --- !u!4 &1915493549183922779 stripped

--- a/Assets/Prefabs/SoupGO.prefab
+++ b/Assets/Prefabs/SoupGO.prefab
@@ -340,3 +340,20 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2584184636553834579, guid: 91d22e101f4254fa5ba1ba25727b46de, type: 3}
   m_PrefabInstance: {fileID: 4128091151128904200}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &7100626090177149643 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6612287871621134531, guid: 91d22e101f4254fa5ba1ba25727b46de, type: 3}
+  m_PrefabInstance: {fileID: 4128091151128904200}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6511056199202629049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7100626090177149643}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 788a1de919df9461c82781b8a42c21d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/SteakGO.prefab
+++ b/Assets/Prefabs/SteakGO.prefab
@@ -274,6 +274,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2.3134022, y: 2.56}
   m_EdgeRadius: 0
+--- !u!114 &267957810664289459
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8916175496185270622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 788a1de919df9461c82781b8a42c21d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3612756911557545615
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ToastGO.prefab
+++ b/Assets/Prefabs/ToastGO.prefab
@@ -86,7 +86,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 29175320056013006}
-  m_BodyType: 0
+  m_BodyType: 2
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0

--- a/Assets/Prefabs/TomatoGO.prefab
+++ b/Assets/Prefabs/TomatoGO.prefab
@@ -373,7 +373,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7100626090177149643}
-  m_BodyType: 0
+  m_BodyType: 2
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0

--- a/Assets/Prefabs/TomatoGO.prefab
+++ b/Assets/Prefabs/TomatoGO.prefab
@@ -412,3 +412,15 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.9258933, y: 2.313403}
   m_EdgeRadius: 0
+--- !u!114 &5591476838707513456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7100626090177149643}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 788a1de919df9461c82781b8a42c21d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/blueberryGO.prefab
+++ b/Assets/Prefabs/blueberryGO.prefab
@@ -373,7 +373,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7100626090177149643}
-  m_BodyType: 0
+  m_BodyType: 2
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0

--- a/Assets/Prefabs/blueberryGO.prefab
+++ b/Assets/Prefabs/blueberryGO.prefab
@@ -412,3 +412,15 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.9258933, y: 2.313403}
   m_EdgeRadius: 0
+--- !u!114 &2082786415588128182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7100626090177149643}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 788a1de919df9461c82781b8a42c21d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/croissantGO.prefab
+++ b/Assets/Prefabs/croissantGO.prefab
@@ -373,7 +373,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7100626090177149643}
-  m_BodyType: 0
+  m_BodyType: 2
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0

--- a/Assets/Prefabs/croissantGO.prefab
+++ b/Assets/Prefabs/croissantGO.prefab
@@ -412,3 +412,15 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.9258933, y: 2.313403}
   m_EdgeRadius: 0
+--- !u!114 &447691668281479264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7100626090177149643}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 788a1de919df9461c82781b8a42c21d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/Final/Level1.unity
+++ b/Assets/Scenes/Final/Level1.unity
@@ -394,6 +394,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 921813218}
     m_Modifications:
+    - target: {fileID: 4705899728089617946, guid: f583bf665a55d410bb32a27ef4357618, type: 3}
+      propertyPath: m_Constraints
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 5330062755574800126, guid: f583bf665a55d410bb32a27ef4357618, type: 3}
       propertyPath: m_RootOrder
       value: 1
@@ -967,6 +971,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 921813218}
     m_Modifications:
+    - target: {fileID: 1053694075802973823, guid: 8990e6c0b9b5c4ede89cc065a11c874e, type: 3}
+      propertyPath: m_Simulated
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1053694075802973823, guid: 8990e6c0b9b5c4ede89cc065a11c874e, type: 3}
+      propertyPath: m_Constraints
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 6306448859142760212, guid: 8990e6c0b9b5c4ede89cc065a11c874e, type: 3}
       propertyPath: m_Name
       value: ChickenGO

--- a/Assets/Scenes/Final/Level2.unity
+++ b/Assets/Scenes/Final/Level2.unity
@@ -1128,6 +1128,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 938293779}
     m_Modifications:
+    - target: {fileID: 6014782237394992160, guid: d075ce63e45ba42c39c08f08cdd6f1f3, type: 3}
+      propertyPath: m_UsedByComposite
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6014782238059803228, guid: d075ce63e45ba42c39c08f08cdd6f1f3, type: 3}
       propertyPath: m_RootOrder
       value: 2
@@ -1184,7 +1188,8 @@ PrefabInstance:
       propertyPath: m_LocalPosition.y
       value: -11.16
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 558847668007123044, guid: d075ce63e45ba42c39c08f08cdd6f1f3, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: d075ce63e45ba42c39c08f08cdd6f1f3, type: 3}
 --- !u!4 &418914959 stripped
 Transform:
@@ -8852,7 +8857,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7835174527326488022}
-  m_RootOrder: 3
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -9916,10 +9921,10 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1658826260}
   - {fileID: 7835174527998858719}
   - {fileID: 1983936808}
   - {fileID: 1714101152}
-  - {fileID: 1658826260}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/IngredientCollisionController.cs
+++ b/Assets/Scripts/IngredientCollisionController.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class IngredientCollisionController : MonoBehaviour
+{
+    private Rigidbody2D rb;
+    // Start is called before the first frame update
+    void Start()
+    {
+        Debug.Log("IngredientCollisionController Start()");
+        rb = GetComponent<Rigidbody2D>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    private void OnCollisionEnter2D(Collision2D other)
+    {
+        Debug.Log("IngredientCollisionController OnCollisionEnter2D");
+        if (!other.gameObject.CompareTag("Player"))
+        {
+            Debug.Log("IngredientCollisionController OnCollisionEnter2D NOT COLLIDING WITH PLAYER");
+            rb.constraints = RigidbodyConstraints2D.FreezePositionY | RigidbodyConstraints2D.FreezePositionX;
+        }
+    }
+}

--- a/Assets/Scripts/IngredientCollisionController.cs
+++ b/Assets/Scripts/IngredientCollisionController.cs
@@ -6,11 +6,12 @@ using UnityEngine;
 public class IngredientCollisionController : MonoBehaviour
 {
     private Rigidbody2D rb;
+    private BoxCollider2D bc;
     // Start is called before the first frame update
     void Start()
     {
-        Debug.Log("IngredientCollisionController Start()");
         rb = GetComponent<Rigidbody2D>();
+        bc = GetComponent<BoxCollider2D>();
     }
 
     // Update is called once per frame
@@ -24,8 +25,8 @@ public class IngredientCollisionController : MonoBehaviour
         Debug.Log("IngredientCollisionController OnCollisionEnter2D");
         if (!other.gameObject.CompareTag("Player"))
         {
-            Debug.Log("IngredientCollisionController OnCollisionEnter2D NOT COLLIDING WITH PLAYER");
-            rb.constraints = RigidbodyConstraints2D.FreezePositionY | RigidbodyConstraints2D.FreezePositionX;
+            rb.bodyType = RigidbodyType2D.Static;
+            bc.isTrigger = true;
         }
     }
 }

--- a/Assets/Scripts/IngredientCollisionController.cs.meta
+++ b/Assets/Scripts/IngredientCollisionController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 788a1de919df9461c82781b8a42c21d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/IngredientController.cs
+++ b/Assets/Scripts/IngredientController.cs
@@ -114,4 +114,11 @@ public class IngredientController : MonoBehaviour
                  ingredientGameObject.GetComponent<SpriteRenderer>().color = new Color(1f, 1f, 1f);
         }
     }
+
+    public bool CanApplyPower(PlayerPowerState state)
+    {
+        return (ingredient.cookType == CookType.WATER && state == PlayerPowerState.WATER_ACTIVE)
+               || (ingredient.cookType == CookType.FIRE && state == PlayerPowerState.FIRE_ACTIVE)
+               || (ingredient.cookType == CookType.AIR && state == PlayerPowerState.AIR_ACTIVE);
+    }
 }

--- a/Assets/Scripts/PlateController.cs
+++ b/Assets/Scripts/PlateController.cs
@@ -12,7 +12,7 @@ public class PlateController : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        bc = this.GetComponent<BoxCollider2D>();
+        bc = GetComponent<BoxCollider2D>();
         rb = GetComponent<Rigidbody2D>();
     }
 

--- a/Assets/Scripts/PlayerMovementDevelopment.cs
+++ b/Assets/Scripts/PlayerMovementDevelopment.cs
@@ -547,6 +547,8 @@ public class PlayerMovementDevelopment : MonoBehaviour
         // get parent game object of the ingredient
         Debug.Log("Pick up ingredient with name: " + ingredientGameObject.name);
         Rigidbody2D rb = ingredientGameObject.GetComponent<Rigidbody2D>();
+        BoxCollider2D bc = ingredientGameObject.GetComponent<BoxCollider2D>();
+        bc.isTrigger = false;
         rb.bodyType = RigidbodyType2D.Static; // so player can jump with ingredient
         rb.simulated = false;
         rb.constraints = RigidbodyConstraints2D.None;

--- a/Assets/Scripts/PlayerMovementDevelopment.cs
+++ b/Assets/Scripts/PlayerMovementDevelopment.cs
@@ -6,7 +6,7 @@ using DefaultNamespace;
 using UnityEngine.SceneManagement;
 using UnityEngine.Analytics; 
 
-enum PlayerPowerState
+public enum PlayerPowerState
 {
     FIRE_ACTIVE, WATER_ACTIVE, AIR_ACTIVE, NEUTRAL
 }
@@ -419,14 +419,14 @@ public class PlayerMovementDevelopment : MonoBehaviour
         {
             isOnIngredient = true;
             currentCollidedIngredient = other.gameObject;
-            if (currentPlayerState == PlayerPowerState.FIRE_ACTIVE)
+            IngredientController ic = other.gameObject.GetComponentInParent<IngredientController>();
+            if (ic.CanApplyPower(currentPlayerState)) // need to collide with correct power enabled
             {   
                 if(isFirstIngredientCollected == false) {
                      //timeToGetIngredient =  Time.time - levelZeroStartTime; 
                      isFirstIngredientCollected = true; 
                 }
 
-                IngredientController ic = other.gameObject.GetComponentInParent<IngredientController>();
                 if (ic.currentIngredientState == IngredientCookingState.UNCOOKED || ic.currentIngredientState == IngredientCookingState.COOKING)
                 {
                     //Debug.Log("Time to get Ingredient: " + timeToGetIngredient+ " seconds");  
@@ -491,7 +491,6 @@ public class PlayerMovementDevelopment : MonoBehaviour
         
         if (Input.GetKeyDown(KeyCode.S) && !returnToGroundAfterFlying)
         {
-            Debug.Log("set fly start time");
             flyStartTime = Time.time;
             isAirJump = true;
         }
@@ -550,6 +549,7 @@ public class PlayerMovementDevelopment : MonoBehaviour
         Rigidbody2D rb = ingredientGameObject.GetComponent<Rigidbody2D>();
         rb.bodyType = RigidbodyType2D.Static; // so player can jump with ingredient
         rb.simulated = false;
+        rb.constraints = RigidbodyConstraints2D.None;
         
         GameObject wholeGameObject = ingredientGameObject.transform.parent.gameObject;
         IngredientController ic = wholeGameObject.GetComponent<IngredientController>();


### PR DESCRIPTION
- Make ingredients static rigid bodies
- Make them dynamic when picked up
- Add an IngredientCollisionController to control when ingredient collides with the floor to stop the falling
- Also, add method in IngredientController that can be called to check if an ingredient can be cooked with the given player state.